### PR TITLE
main: add interrupt handler for graceful shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,11 +1,28 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
+	"os/signal"
 )
+
+func withCancelOnInterrupt(ctx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(ctx)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+		cancel()
+	}()
+	return ctx, cancel
+}
 
 func main() {
 	logger := log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lshortfile)
-	logger.Println("Hello, world!")
+	ctx, cancel := withCancelOnInterrupt(context.Background())
+	defer cancel()
+	logger.Println("waiting for interrupt")
+	<-ctx.Done()
+	logger.Println("interrupted, goodbye")
 }


### PR DESCRIPTION
This provides a neat way of doing cleanup after an interrupt, if any is needed. It also paves the way for more quickly iterating on this program by being able to stop it cleanly at any time.