### PR TITLE
Add an outline of the switching functionality

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 
 	// Create a `Switcher`.
 	logger.Println("creating switcher")
-	switcher := NewSwitcher(logger, watcher.Focused())
+	switcher := NewSwitcher(logger, xu, watcher.Focused())
 	logger.Println("created switcher")
 
 	// Set up an errgroup with a derived context that is cancelled when an


### PR DESCRIPTION
This PR adds a `Switcher` type that will eventually be tasked with performing the keyboard layout switching logic. Right now, it simply consumes focus events, and outputs the class of the focused windows; this is what eventually will be used to decide the keyboard layout to choose.